### PR TITLE
Create Katana config

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -7,6 +7,10 @@
     the PATH. Runs in `local` mode - all jobs will be run on the logged in environment.
 ----------------------------------------------------------------------------------------
 */
+params {
+    cpuQueue = 'submission'
+    gpuQueue = 'mwacgpu2'
+}
 
 process {
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -19,6 +19,8 @@ process {
     memory = { check_max( 6.GB * task.attempt, 'memory' ) }
     time   = { check_max( 4.h  * task.attempt, 'time'   ) }
 
+    executor = 'pbspro'
+
     errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'

--- a/conf/katana.config
+++ b/conf/katana.config
@@ -1,0 +1,71 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    nf-core/proteinfold Nextflow base config file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    A 'blank slate' config file, appropriate for general use on most high performance
+    compute environments. Assumes that all software is installed and available on
+    the PATH. Runs in `local` mode - all jobs will be run on the logged in environment.
+----------------------------------------------------------------------------------------
+*/
+params {
+    cpuQueue = 'submission'
+    gpuQueue = 'mwacgpu2'
+}
+
+process {
+
+    // TODO nf-core: Check the defaults for all processes
+    cpus   = { check_max( 1    * task.attempt, 'cpus'   ) }
+    memory = { check_max( 6.GB * task.attempt, 'memory' ) }
+    time   = { check_max( 4.h  * task.attempt, 'time'   ) }
+
+    executor = 'pbspro'
+
+    errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+    maxRetries    = 1
+    maxErrors     = '-1'
+
+    // Process-specific resource requirements
+    // NOTE - Please try and re-use the labels below as much as possible.
+    //        These labels are used and recognised by default in DSL2 files hosted on nf-core/modules.
+    //        If possible, it would be nice to keep the same label naming convention when
+    //        adding in your local modules too.
+    // TODO nf-core: Customise requirements for specific processes.
+    // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
+    withLabel:process_single {
+        cpus   = { check_max( 1                  , 'cpus'    ) }
+        memory = { check_max( 6.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 4.h  * task.attempt, 'time'    ) }
+    }
+    withLabel:process_low {
+        cpus   = { check_max( 2     * task.attempt, 'cpus'    ) }
+        memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 4.h   * task.attempt, 'time'    ) }
+    }
+    withLabel:process_medium {
+        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
+        memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 8.h   * task.attempt, 'time'    ) }
+    }
+    withLabel:process_high {
+        cpus   = { check_max( 12    * task.attempt, 'cpus'    ) }
+        memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 16.h  * task.attempt, 'time'    ) }
+    }
+    withLabel:process_long {
+        time   = { check_max( 20.h  * task.attempt, 'time'    ) }
+    }
+    withLabel:process_high_memory {
+        memory = { check_max( 200.GB * task.attempt, 'memory' ) }
+    }
+    withLabel:error_ignore {
+        errorStrategy = 'ignore'
+    }
+    withLabel:error_retry {
+        errorStrategy = 'retry'
+        maxRetries    = 2
+    }
+    withName:CUSTOM_DUMPSOFTWAREVERSIONS {
+        cache = false
+    }
+}

--- a/conf/katana.config
+++ b/conf/katana.config
@@ -68,4 +68,13 @@ process {
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {
         cache = false
     }
+    withLabel:gpu_compute {
+        queue = "${params.gpuQueue}" 
+        accelerator = 1
+        clusterOptions = { "-l select=1:ngpus=1:ncpus=${task.cpus}:mem=${task.memory.toMega()}mb" }
+
+        containerOptions = {
+            workflow.containerEngine == "singularity" ? '--nv' : ( workflow.containerEngine == "docker" ? '--gpus all' : none )
+        }
+    }
 }


### PR DESCRIPTION
Created configuration file containing options allowing for labeled processes to be pushed to GPU nodes via Katana's scheduler.

## TODO:
- Label GPU processes with `gpu_compute`